### PR TITLE
doc update per bug 54719

### DIFF
--- a/healthvault/getting-started/invite-patients.md
+++ b/healthvault/getting-started/invite-patients.md
@@ -21,7 +21,7 @@ At a high level, the process to generate and send invitation codes is:
 
 Once users receive their invitation, they will be invited to download the HealthVault Insights app, sign-up/sign-in to HealthVault and give consent to your application's request to access specific health data. Once consent is received, your application will have access to user’s consented data.
 
-Your application will need to retrieve all user's healthvault identity and match them up with the user's identity from your ecosystem. See guide on [alternate user identifiers](../../healthvault/concepts/advanced/alternate-user-identifiers.md) to retrieve the list of your patient's and associate an alternate id from your ecosystem.
+Your application will need to retrieve all user's healthvault identity and match them up with the user's identity from your ecosystem. See guide on [alternate user identifiers](/healthvault/concepts/advanced/alternate-user-identifiers) to retrieve the list of your patient's and associate an alternate id from your ecosystem.
 
 > [!NOTE]
 > In order to use remote monitoring scenarios, users must register their account in the HealthVault Insights app in order to receive remote monitoring scenarios. HealthVault Insights is currently only available to users in the United States and the United Kingdom.

--- a/healthvault/getting-started/invite-patients.md
+++ b/healthvault/getting-started/invite-patients.md
@@ -19,7 +19,9 @@ At a high level, the process to generate and send invitation codes is:
 3.  Generate an invitation code using the [Onboarding REST API](https://developer.healthvault.com/Api).
 4.  Send the invitation code to your participant using email or another mechanism.
 
-Once users receive their invitation, they will be invited to download the HealthVault Insights app, sign-up/sign-in to HealthVault and consent to Fabrikam Health solutions to complete joining the program. On completion, Fabrikam will have access to user’s consented data.
+Once users receive their invitation, they will be invited to download the HealthVault Insights app, sign-up/sign-in to HealthVault and give consent to your application's request to access specific health data. Once consent is received, your application will have access to user’s consented data.
+
+Your application will need to retrieve all user's healthvault identity and match them up with the user's identity from your ecosystem. See guide on [alternate user identifiers](../../healthvault/concepts/advanced/alternate-user-identifiers.md) to retrieve the list of your patient's and associate an alternate id from your ecosystem.
 
 > [!NOTE]
 > In order to use remote monitoring scenarios, users must register their account in the HealthVault Insights app in order to receive remote monitoring scenarios. HealthVault Insights is currently only available to users in the United States and the United Kingdom.


### PR DESCRIPTION
Text changes illustrates how users can retrieve (and associate) alternate user ids from invited patients. Also updated text where Fabrikam Health solutions was being mentioned.