### PR TITLE
Updates README.md to have properly formatted markdown and a link to the live documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Microsoft HealthVault Documentation
-The markup and publishing content used to generate the [HealthVault documentation](https://review.docs.microsoft.com/en-us/healthvault).
+The markup and publishing content used to generate the [HealthVault documentation](http://docs.microsoft.com/healthvault).
 
 ## Legal Notices
 Microsoft and any contributors grant you a license to the Microsoft documentation and other content

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-##Legal Notices
+# Microsoft HealthVault Documentation
+The markup and publishing content used to generate the [HealthVault documentation](https://review.docs.microsoft.com/en-us/healthvault).
+
+## Legal Notices
 Microsoft and any contributors grant you a license to the Microsoft documentation and other content
 in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
 see the [LICENSE](LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the


### PR DESCRIPTION
The secondary header for the License in the README.md was improperly formatted (missing space) and there was no title of the repo nor description with link to the live docs.