### PR TITLE
Remove "Home" hub page link from TOC

### DIFF
--- a/healthvault/TOC.md
+++ b/healthvault/TOC.md
@@ -1,5 +1,3 @@
-# [Home](/healthvault/index)
-
 # [Introduction](/healthvault/introduction/introduction)
 ## [Why HealthVault](/healthvault/introduction/why-healthvault)
 ## [Technical Overview](/healthvault/introduction/technical-overview)


### PR DESCRIPTION
The home page is already linked in the header, in a much more intuitive way. It's a much clearer experience if we avoid duplicating links in the TOC like that. 

Let me know if you have any questions!

- sabarret, information architect for Docs