### PR TITLE
typo: occurance -> occurrence

### DIFF
--- a/healthvault/apis/2.0-preview.swagger.json
+++ b/healthvault/apis/2.0-preview.swagger.json
@@ -2711,7 +2711,7 @@
                     "type": "string"
                 },
                 "trackingDateTime": {
-                    "description": "The date and time of the task occurance.",
+                    "description": "The date and time of the task occurrence.",
                     "type": "object",
                     "x-id": "ZonedDateTime"
                 }


### PR DESCRIPTION
Given swagger is usually a generated file, this might be a product bug