### PR TITLE
Adding banner to go-live and become a solution provider pages

### DIFF
--- a/healthvault/publishing/become-a-solution-provider.md
+++ b/healthvault/publishing/become-a-solution-provider.md
@@ -10,7 +10,9 @@ description: Learn about the process for becoming a HealthVault solution provide
 
 # Process for becoming a HealthVault solution provider
 
->## We are not currently accepting any new requests fr onboarding providers.  We are alive and well.
+>## Thank you for your interest in HealthVault. Microsoft is making significant investments in healthcare technology to bring even greater value and benefits to our partners and customers.
+>## In the near term, we are continuing to support our current Solutions Partners but are not onboarding new HealthVault Solutions Providers.
+
 There are four phases to becoming a HealthVault Solution Provider:
 
 1.  [Learn – Learn about HealthVault (FAQs)](#learn---frequently-asked-questions)

--- a/healthvault/publishing/go-live.md
+++ b/healthvault/publishing/go-live.md
@@ -11,6 +11,9 @@ description: Understand the process for publishing your app in the HealthVault p
 Go-live guide
 =============
 
+>## Thank you for your interest in HealthVault. Microsoft is making significant investments in healthcare technology to bring even greater value and benefits to our partners and customers.
+>## In the near term, we are continuing to support our current Solutions Partners but are not onboarding new HealthVault Solutions Providers.
+
 It’s easy to get started with HealthVault. There is no charge during the first year of use, up to 250,000 user accounts. Please [contact our business team](https://www.healthvault.com/en-us/contact-us) for pricing details thereafter. We have plans designed to meet the needs of organizations of all sizes.
 
 The Go-Live process typically takes two to four weeks depending upon how closely you have followed the instructions and guidelines below. However, the go-live process can take significantly less time when the HealthVault application and all documentation is ready. If you already have a live application that is integrated with the HealthVault production environment and you are planning to ship an update, please review the guide [Updating a HealthVault-integrated application](/healthvault/publishing/updates).


### PR DESCRIPTION
Adding banner to go-live and become a solution provider pages to remind providers we are not currently onboarding new apps at this time.